### PR TITLE
Add Bank Storage + EMI support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,8 @@ dependencies {
 	modRuntimeOnly "me.shedaniel:RoughlyEnoughItems-fabric:$rei_version"
 	modCompileOnly "me.shedaniel:RoughlyEnoughItems-api-fabric:$rei_version"
 	modCompileOnly "me.shedaniel:RoughlyEnoughItems-default-plugin-fabric:$rei_version"
+	// EMI
+	modCompileOnly "dev.emi:emi-fabric:${project.emi_version}:api"
 
 	// botania api?!
 	modCompileOnlyApi("vazkii.botania:Botania:${botania_version}")

--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,8 @@ dependencies {
 	// EMI
 	modCompileOnly "dev.emi:emi-fabric:${project.emi_version}:api"
 
+	// Bank Storage
+	modCompileOnlyApi "maven.modrinth:bank-storage:${project.bankstorage_version}"
 	// botania api?!
 	modCompileOnlyApi("vazkii.botania:Botania:${botania_version}")
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,5 +19,5 @@ owo_version=0.11.2+1.20
 emi_version=1.1.7+1.20.1
 rei_version=12.1.725
 
-cca_version = 5.2.2
+bankstorage_version=1.2.0
 botania_version = 1.20.1-445-FABRIC-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,8 @@ archives_base_name=constructionwand
 # Dependencies
 fabric_version=0.92.1+1.20.1
 owo_version=0.11.2+1.20
-rei_version = 12.1.725
+emi_version=1.1.7+1.20.1
+rei_version=12.1.725
 
 cca_version = 5.2.2
 botania_version = 1.20.1-445-FABRIC-SNAPSHOT

--- a/src/main/java/pw/smto/constructionwand/containers/ContainerRegistrar.java
+++ b/src/main/java/pw/smto/constructionwand/containers/ContainerRegistrar.java
@@ -2,6 +2,7 @@ package pw.smto.constructionwand.containers;
 
 import net.fabricmc.loader.api.FabricLoader;
 import pw.smto.constructionwand.ConstructionWand;
+import pw.smto.constructionwand.containers.handlers.HandlerBankStorage;
 import pw.smto.constructionwand.containers.handlers.HandlerBotania;
 import pw.smto.constructionwand.containers.handlers.HandlerBundle;
 import pw.smto.constructionwand.containers.handlers.HandlerCapability;
@@ -13,6 +14,11 @@ public class ContainerRegistrar
         ConstructionWand.containerManager.register(new HandlerCapability());
         ConstructionWand.containerManager.register(new HandlerShulkerbox());
         ConstructionWand.containerManager.register(new HandlerBundle());
+
+        if(FabricLoader.getInstance().isModLoaded("bankstorage")) {
+            ConstructionWand.containerManager.register(new HandlerBankStorage());
+            ConstructionWand.LOGGER.info("Bank Storage integration added");
+        }
 
         if(FabricLoader.getInstance().isModLoaded("botania")) {
             ConstructionWand.containerManager.register(new HandlerBotania());

--- a/src/main/java/pw/smto/constructionwand/containers/handlers/HandlerBankStorage.java
+++ b/src/main/java/pw/smto/constructionwand/containers/handlers/HandlerBankStorage.java
@@ -1,0 +1,48 @@
+package pw.smto.constructionwand.containers.handlers;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.natte.bankstorage.container.BankItemStorage;
+import net.natte.bankstorage.item.BankItem;
+import net.natte.bankstorage.item.CachedBankStorage;
+import net.natte.bankstorage.util.Util;
+import pw.smto.constructionwand.api.IContainerHandler;
+import pw.smto.constructionwand.basics.WandUtil;
+
+public class HandlerBankStorage implements IContainerHandler {
+    @Override
+    public boolean matches(PlayerEntity player, ItemStack itemStack, ItemStack inventoryStack) {
+        return inventoryStack != null && inventoryStack.getCount() == 1 && inventoryStack.getItem() instanceof BankItem;
+    }
+
+    @Override
+    public int countItems(PlayerEntity player, ItemStack itemStack, ItemStack inventoryStack) {
+        CachedBankStorage cachedBankStorage = CachedBankStorage.getBankStorage(inventoryStack);
+        if(cachedBankStorage == null) return 0;
+
+        return cachedBankStorage.blockItems.stream().filter(stack -> WandUtil.stackEquals(stack, itemStack)).map(ItemStack::getCount).reduce(0, Integer::sum);
+    }
+
+    @Override
+    public int useItems(PlayerEntity player, ItemStack itemStack, ItemStack inventoryStack, int count) {
+        BankItemStorage bankItemStorage = Util.getBankItemStorage(inventoryStack, player.getWorld());
+        if(bankItemStorage == null) return 0;
+
+        for(int i = 0; i < bankItemStorage.getItems().size(); i++) {
+            ItemStack handlerStack = bankItemStorage.getItems().get(i);
+            if(WandUtil.stackEquals(itemStack, handlerStack)) {
+                ItemStack extracted = bankItemStorage.removeStack(i, count);
+                count -= extracted.getCount();
+                if(count <= 0) break;
+            }
+        }
+
+        if(EnvType.CLIENT.equals(FabricLoader.getInstance().getEnvironmentType())) {
+            CachedBankStorage.requestCacheUpdate(Util.getUUID(inventoryStack));
+        }
+
+        return count;
+    }
+}

--- a/src/main/java/pw/smto/constructionwand/integrations/emi/ConstructionWandEmiPlugin.java
+++ b/src/main/java/pw/smto/constructionwand/integrations/emi/ConstructionWandEmiPlugin.java
@@ -1,0 +1,61 @@
+package pw.smto.constructionwand.integrations.emi;
+
+import dev.emi.emi.api.EmiPlugin;
+import dev.emi.emi.api.EmiRegistry;
+import dev.emi.emi.api.recipe.EmiInfoRecipe;
+import dev.emi.emi.api.stack.EmiStack;
+import net.minecraft.client.util.InputUtil;
+import net.minecraft.item.Item;
+import net.minecraft.registry.Registries;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
+import net.minecraft.util.Identifier;
+import pw.smto.constructionwand.ConstructionWand;
+import pw.smto.constructionwand.Registry;
+import pw.smto.constructionwand.basics.ConfigClient;
+import pw.smto.constructionwand.basics.ConfigServer;
+
+import java.util.List;
+
+public class ConstructionWandEmiPlugin implements EmiPlugin {
+    private static final String baseKey = ConstructionWand.MOD_ID + ".description.";
+    private static final String baseKeyItem = "item." + ConstructionWand.MOD_ID + ".";
+
+    @Override
+    public void register(EmiRegistry registry) {
+        Text optkeyText = Text.translatable(InputUtil.fromKeyCode(ConfigClient.OPT_KEY.get(), -1).getTranslationKey())
+                .formatted(Formatting.BLUE);
+        Text wandModeText = keyComboText(ConfigClient.SHIFTOPT_MODE.get(), optkeyText);
+        Text wandGuiText = keyComboText(ConfigClient.SHIFTOPT_GUI.get(), optkeyText);
+
+        for(Item wand : Registry.Items.WANDS) {
+            ConfigServer.WandProperties wandProperties = ConfigServer.getWandProperties(wand);
+
+            String durabilityKey = wand == Registry.Items.INFINITY_WAND ? "unlimited" : "limited";
+            Text durabilityText = Text.translatable(baseKey + "durability." + durabilityKey, wandProperties.getDurability());
+
+            registry.addRecipe(new EmiInfoRecipe(
+                    List.of(EmiStack.of(wand)),
+                    List.of(Text.translatable(baseKey + "wand",
+                            Text.translatable(baseKeyItem + Registries.ITEM.getId(wand).getPath()),
+                            wandProperties.getLimit(), durabilityText, optkeyText, wandModeText, wandGuiText)),
+                    new Identifier(ConstructionWand.MOD_ID, Registries.ITEM.getId(wand).getPath() + "_info")
+            ));
+        }
+
+        for(Item core : Registry.Items.CORES) {
+            registry.addRecipe(new EmiInfoRecipe(
+                    List.of(EmiStack.of(core)),
+                    List.of(Text.translatable(baseKey + Registries.ITEM.getId(core).getPath())
+                            .append("\n\n")
+                            .append(Text.translatable(baseKey + "core", wandModeText))),
+                    new Identifier(ConstructionWand.MOD_ID, Registries.ITEM.getId(core).getPath() + "_info")
+            ));
+        }
+    }
+
+    private Text keyComboText(boolean shiftOpt, Text optkeyText) {
+        String key = shiftOpt ? "sneak_opt" : "sneak";
+        return Text.translatable(baseKey + "key." + key, optkeyText).formatted(Formatting.BLUE);
+    }
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -30,6 +30,9 @@
 		"client": [
 			"pw.smto.constructionwand.ConstructionWandClient"
 		],
+		"emi": [
+			"pw.smto.constructionwand.integrations.emi.ConstructionWandEmiPlugin"
+		],
 		"rei_client": [
 			"pw.smto.constructionwand.integrations.rei.ConstructionWandReiPlugin"
 		]


### PR DESCRIPTION
This PR adds support for [Bank Storage](https://modrinth.com/mod/bank-storage)'s "banks" as item suppliers for construction wands, as well as [EMI](https://modrinth.com/mod/emi) as an alternative to REI for viewing item info.